### PR TITLE
fix: auth api

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -210,7 +210,7 @@ ALTER TABLE ONLY public.users
 --
 
 ALTER TABLE ONLY public.board_columns
-    ADD CONSTRAINT board_columns_board_id_fkey FOREIGN KEY (board_id) REFERENCES public.boards(id);
+    ADD CONSTRAINT board_columns_board_id_fkey FOREIGN KEY (board_id) REFERENCES public.boards(id) ON DELETE CASCADE;
 
 
 --
@@ -218,7 +218,7 @@ ALTER TABLE ONLY public.board_columns
 --
 
 ALTER TABLE ONLY public.boards
-    ADD CONSTRAINT boards_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+    ADD CONSTRAINT boards_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
 
 --
@@ -234,7 +234,7 @@ ALTER TABLE ONLY public.forgot_password
 --
 
 ALTER TABLE ONLY public.sub_tasks
-    ADD CONSTRAINT sub_tasks_task_id_fkey FOREIGN KEY (task_id) REFERENCES public.tasks(id);
+    ADD CONSTRAINT sub_tasks_task_id_fkey FOREIGN KEY (task_id) REFERENCES public.tasks(id) ON DELETE CASCADE;
 
 
 --
@@ -242,7 +242,7 @@ ALTER TABLE ONLY public.sub_tasks
 --
 
 ALTER TABLE ONLY public.tasks
-    ADD CONSTRAINT tasks_board_column_id_fkey FOREIGN KEY (board_column_id) REFERENCES public.board_columns(id);
+    ADD CONSTRAINT tasks_board_column_id_fkey FOREIGN KEY (board_column_id) REFERENCES public.board_columns(id) ON DELETE CASCADE;
 
 
 --
@@ -265,4 +265,5 @@ ALTER TABLE ONLY public.user_verification
 INSERT INTO public.schema_migrations (version) VALUES
     ('20260328120117'),
     ('20260330002030'),
-    ('20260401061411');
+    ('20260401061411'),
+    ('20260407081531');

--- a/src/database/migrations/20260407081531_add-on-delete-cascade-to-fkey.sql
+++ b/src/database/migrations/20260407081531_add-on-delete-cascade-to-fkey.sql
@@ -1,0 +1,70 @@
+-- migrate:up
+
+ALTER TABLE sub_tasks
+DROP CONSTRAINT IF EXISTS sub_tasks_task_id_fkey;
+
+ALTER TABLE sub_tasks
+ADD CONSTRAINT sub_tasks_task_id_fkey
+FOREIGN KEY (task_id) REFERENCES tasks(id)
+ON DELETE CASCADE;
+
+
+ALTER TABLE tasks
+DROP CONSTRAINT IF EXISTS tasks_board_column_id_fkey;
+
+ALTER TABLE tasks
+ADD CONSTRAINT tasks_board_column_id_fkey
+FOREIGN KEY (board_column_id) REFERENCES board_columns(id)
+ON DELETE CASCADE;
+
+
+ALTER TABLE board_columns
+DROP CONSTRAINT IF EXISTS board_columns_board_id_fkey;
+
+ALTER TABLE board_columns
+ADD CONSTRAINT board_columns_board_id_fkey
+FOREIGN KEY (board_id) REFERENCES boards(id)
+ON DELETE CASCADE;
+
+
+ALTER TABLE boards
+DROP CONSTRAINT IF EXISTS boards_user_id_fkey;
+
+ALTER TABLE boards
+ADD CONSTRAINT boards_user_id_fkey
+FOREIGN KEY (user_id) REFERENCES users(id)
+ON DELETE CASCADE;
+
+
+-- migrate:down
+
+ALTER TABLE boards
+DROP CONSTRAINT boards_user_id_fkey;
+
+ALTER TABLE boards
+ADD CONSTRAINT boards_user_id_fkey
+FOREIGN KEY (user_id) REFERENCES users(id);
+
+
+ALTER TABLE board_columns
+DROP CONSTRAINT board_columns_board_id_fkey;
+
+ALTER TABLE board_columns
+ADD CONSTRAINT board_columns_board_id_fkey
+FOREIGN KEY (board_id) REFERENCES boards(id);
+
+
+ALTER TABLE tasks
+DROP CONSTRAINT tasks_board_column_id_fkey;
+
+ALTER TABLE tasks
+ADD CONSTRAINT tasks_board_column_id_fkey
+FOREIGN KEY (board_column_id) REFERENCES board_columns(id);
+
+
+ALTER TABLE sub_tasks
+DROP CONSTRAINT sub_tasks_task_id_fkey;
+
+ALTER TABLE sub_tasks
+ADD CONSTRAINT sub_tasks_task_id_fkey
+FOREIGN KEY (task_id) REFERENCES tasks(id);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -232,7 +232,7 @@ export const loginService = async (payload: ILoginPayload) => {
         const token = jwt.sign(
             { id: user.id, email },
             process.env.JWT_SECRET as string,
-            { expiresIn: "1hr" }
+            { expiresIn: "2hr" }
         )
 
         return { token };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -20,6 +20,7 @@ export const validate = (schema: IValidationSchema) => {
             return next();
         } catch (error: any) {
             const parsedError = JSON.parse(error);
+            console.error(parsedError);
             return catchError(parsedError?.[0]?.message, res, 400);
         }
     }

--- a/src/validations/index.ts
+++ b/src/validations/index.ts
@@ -101,12 +101,9 @@ export const validateUpdateTask = validate({
 export const validateCreateTask = validate({
     body: z.object({
         title: z.string("Task title has to be a string").min(3, "Task title must be at least 3 characters"),
-        description: z.string("Description must be a string").optional(),
         boardColumnId: z.uuid("Invalid column id"),
-        subTasks: z.array(z.object({
-            title: z.string("Subtask title must be a string"),
-            isCompleted: z.boolean("isCompleted must be a boolean").optional(),
-        })).optional(),
+        description: z.string("Description must be a string").optional(),
+        subTasks: z.array(z.string("Subtask title must be a string")).optional(),
     }),
 })
 


### PR DESCRIPTION
This pull request introduces a database migration to enforce cascading deletes on key foreign key relationships in the schema, ensuring that related records are automatically removed when a parent record is deleted. It also includes a few minor improvements to authentication and validation logic.

**Database schema improvements:**

* Added `ON DELETE CASCADE` to foreign key constraints in `boards`, `board_columns`, `tasks`, and `sub_tasks` tables, ensuring that deleting a parent record (e.g., a board) will also delete all dependent records (e.g., columns, tasks, sub-tasks) automatically. This is implemented via a new migration file and reflected in `db/schema.sql`. [[1]](diffhunk://#diff-1bfc523c8e11b17a17402c2fe4f068a06a43b23dbe197c352f717cddacfbab34R1-R70) [[2]](diffhunk://#diff-948c089a4de6325dd9a8f187fb0116272dedf46306023dce6d70b548e9f7539cL213-R221) [[3]](diffhunk://#diff-948c089a4de6325dd9a8f187fb0116272dedf46306023dce6d70b548e9f7539cL237-R245) [[4]](diffhunk://#diff-948c089a4de6325dd9a8f187fb0116272dedf46306023dce6d70b548e9f7539cL268-R269)

**Authentication and validation updates:**

* Increased JWT token expiration from 1 hour to 2 hours in the `loginService` for improved user experience.
* Improved error handling in the validation utility by logging parsed errors to the console, aiding debugging.
* Simplified the sub-task validation in `validateCreateTask` to accept an array of strings (sub-task titles) instead of objects, making the API contract clearer and easier to use.